### PR TITLE
STBank: fix a warning by mypy [vNone]

### DIFF
--- a/middlewares/check_user.py
+++ b/middlewares/check_user.py
@@ -19,7 +19,7 @@ class UserCheckMiddleware(BaseMiddleware):
             data: dict[str, Any]
         ):
         if isinstance(event, Message):
-            if event.from_user is None:
+            if event.from_user is None or event.text is None:
                 return
             user_id = event.from_user.id
             text = event.text.lower() or ""


### PR DESCRIPTION
Исправлен варнинг от mypy, который говорил о том, что в мидлваре event.text мог быть None